### PR TITLE
Fix the document accessibility

### DIFF
--- a/accessible_math_documentation_page.html
+++ b/accessible_math_documentation_page.html
@@ -34,12 +34,12 @@
 </head>
 
 <body>
+  <header>Accessible Mathematics</header>
 
   <!-- navbar must be on left side and always visible for landscape viewports  -->
   <!-- link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Sanchez|Roboto|Nunito" -->
 
   <nav id="navbar">
-    <header>Accessible Mathematics</header>
     <ul>
       <li> <a href="#introduction" class="nav-link">Introduction</a></li>
       <li> <a href="#problem_statement" class="nav-link">Problem Statement</a></li>
@@ -61,7 +61,7 @@
   <main id="main-doc">
     <a name="top"></a>
     <section class="main-section" id="introduction">
-      <header>Introduction</header>
+      <h1>Introduction</h1>
       <article>
         <p>What is Accessible Mathematics?</p>
         <p>Accessibility and Accessible Design are a wide net of principles and practices to build inclusive
@@ -72,7 +72,7 @@
       </article>
     </section>
     <section class="main-section" id="problem_statement">
-      <header>Problem Statement</header>
+      <h1>Problem Statement</h1>
       <article>
         <p>Braille, Screen Readers, Human Narration, and Tactile Sign language are four approaches to convey written
           text to visually impaired readers. Conveying mathematics is more subtle, however, because mathematical
@@ -119,7 +119,7 @@
       </article>
     </section>
     <section class="main-section" id="sample_workflow">
-      <header>Sample Workflow</header>
+      <h1>Sample Workflow</h1>
       <article>
         <p>Here is a high level sample workflow:</p>
         <ol>
@@ -153,7 +153,7 @@
       </article>
     </section>
     <section class="main-section" id="math_markup_languages">
-      <header>Math Markup Languages</header>
+      <h1>Math Markup Languages</h1>
       <article>
         <p>The majority of mathematics today is written in a markup language. The most widely used math markup languages are: </p>
         <ol>
@@ -167,7 +167,7 @@
           the placement of the symbols. LaTeX was originally designed for print or presentation on a fixed canvas size.
           MathML and AsciiMath were originally designed for the web to accommodate a flexible canvas. An accessible math
           workflow today may use a blend of both.</p>
-        <h1>LaTeX</h1>
+        <h2>LaTeX</h2>
         <p>The <a href="https://www.latex-project.org/" target="_blank">LaTeX typesetting system</a> is the most popular
           method for typesetting mathematics. LaTeX is an outgrowth of
           TeX, a markup language and layout engine created in the 1985 to standardize typesetting mathematics and
@@ -179,7 +179,7 @@
           artistic needs.</p>
         <p>LaTeX markup can be written in any text editor, but the LaTeX typesetting engine is required to render the
           mathematical output. This is discussed in the next section on <a href="">Typesetting Software</a>.
-        <h1>MathML</h1>
+        <h2>MathML</h2>
         <p><a href="https://www.w3.org/Math/" target="_blank">MathML</a> was created in 1998 as an extension of
           <abbr>HTML</abbr> specifically to render mathematics on the
           web. This provides all the benefits of reflowable text on any device, and a direct interface to mathematical
@@ -192,14 +192,14 @@
         </p>
         <p>MathML can also be written in any text editor, but is generally coded with <abbr>GUI</abbr> editors or
           conversion tools from LaTeX or other XML formats.</p>
-        <h1>AsciiMath</h1>
+        <h2>AsciiMath</h2>
         <p><a href="http://asciimath.org/" target="_blank">AsciiMath</a> is a math markup language for a small set of
           the most commonly used mathematical symbols. The
           syntax for a symbol is meant to mimic the symbol it represents, similar in spirit to emotive
           <abbr>ASCII</abbr> expressions that predate modern emoticons. It shares some similarity with basic LaTeX
           markup.
         </p>
-        <h1>Plain Text</h1>
+        <h2>Plain Text</h2>
         <p>The <a href="https://unicode-table.com/en/sets/mathematical-signs/" target="_blank">Unicode Character Set</a>
           contains a large collection of mathematical symbols that can be typed in plain
           text, without any special markup. This is only practical for very basic mathematical expressions, as it does
@@ -210,13 +210,13 @@
       </article>
     </section>
     <section class="main-section" id="typesetting_software">
-      <header>Typesetting Software</header>
+      <h1>Typesetting Software</h1>
       <article>
         <p>Any math markup can be written in any plain text editor, but a typesetting engine is needed to interpret the
           markup and render the resulting mathematics. Thus, most authors use an integrated development environment
           (<abbr>IDE</abbr>), a software suite that provides all the necessary functionality in one package. A few
           popular software tools are listed here, but there are many more available with their own unique features.</p>
-        <h1>LaTeX</h1>
+        <h2>LaTeX</h2>
         <p>The LaTeX typesetting system includes:</p>
         <ul>
           <li>The core typesetting engine</li>
@@ -250,7 +250,7 @@
         <p>
           <a href="https://www.chikrii.com" target="_blank">Chikrii Software</a> offers the Tex2Word and Word2Tex converters for Microsoft Word to read and save documents in <span class="inline-code">tex</span> format. LaTeX formulas are rendered as MathML objects in Word, and vice versa.
         </p>
-        <h1>MathML</h1>
+        <h2>MathML</h2>
         <p> 
           MathML can be coded in any editor just like HTML.  Most authors prefer to use a <abbr>GUI</abbr> editor rather than code MathML directly.  To see why, please see the <a href="#code_examples">Code Examples</a> section for a comparison of MathML and LaTeX.</p>
         <p>Popular MathML <abbr>GUI</abbr> editors:</p>
@@ -275,11 +275,11 @@
         </ul>
         <p>To remedy this last point, there are Javascript tools that will render MathML in any modern
           browser. This is discussed in the <a href="">Web Display Engines</a> section.</p>
-        <h1>AsciiMath</h1>
+        <h2>AsciiMath</h2>
         <p>AsciiMath can be written with a text editor or any <abbr>HTML</abbr> authoring software. It is rendered in a
           web browsers with the MathJax display engine. Instructions are provided on the <a href="">AsciiMath home
             page</a>.</p>
-        <h1>GNU TeXmacs</h1>
+        <h2>GNU TeXmacs</h2>
         <p><a href="" target="_blank">GNU TeXmacs</a> is a typesetting system that uses its own internal markup for rendering mathematics and scientific expressions. It was created as an alternative to LaTeX, incorporating realtime rendering and a more standardized internal data structure that can export to several different output formats. It is free and extensible, and can also operate as a front end for a number of other powerful mathematical software packages.
         </p>
         <p>Unfortunately, there is no mention of accessibility support in the TeXmacs documentation. Further testing is needed to determine how
@@ -288,7 +288,7 @@
       </article>
     </section>
     <section class="main-section" id="web_display_engines">
-      <header>Web Display Engines</header>
+      <h1>Web Display Engines</h1>
       <article>
         <p>
           LaTeX is widely adopted and efficient to code, but does not yet provide a navigable document structure to assistive technology. MathML provides this structure, but it is much longer to code and not supported in some browsers. To bridge this gap, there are JavaScript tools that convert LaTeX markup to MathML and display the MathML in a browser:
@@ -303,7 +303,7 @@
         <p>
           These tools aim to provide a "best of both worlds" approach, where assistive technology can navigate MathML just as easily as <abbr>HTML</abbr>, while the underlying LaTeX markup can be translated to screen reader and Braille output. Each varies in its scope, method of application, and accessibility support.
         </p>
-        <h1>MathJax</h1>
+        <h2>MathJax</h2>
         <p><a href="https://www.mathjax.org/" target="_blank">MathJax</a> is the most popular method to render
           mathematics on the web. The MathJax engine searches an <abbr>HTML</abbr> document for mathematics markup
           embedded between LaTeX-style math mode delimiters (which are customizable), and renders it as math content on
@@ -312,24 +312,24 @@
           (<abbr>SRE</abbr>). It integrates well with major content and learning management systems, and its excellent
           accessibility support makes it a key component of porting long-form mathematics into accessible friendly
           formats.</p>
-        <h1>KaTeX</h1>
+        <h2>KaTeX</h2>
         <p><a href="https://katex.org/" target="_blank">KaTeX</a> is an engine that purports to render much faster than
           MathJax. This can provide a significant load time speedup for longer documents with a dense amount of LaTeX
           markup. Unfortunately, at this time, KaTeX has zero accessibility support, as assistive technology cannot read
           the MathML rendered by KaTeX. Therefore, it is <strong>not advisable</strong> to use KaTeX to port mathematics
           for non-sighted users.</p>
-        <h1>MathLive</h1>
+        <h2>MathLive</h2>
         <p><a href="https://cortexjs.io/mathlive/" target="_blank">MathLive</a> is a component of the <a
             href="https://cortexjs.io/" target="_blank">Cortex.js</a> family of web-based mathematical applications.
           MathLive accepts LaTeX input, offers a virtual keyboard with popular mathematical symbols, and offers a choice
           between its own built-in speech rules for screen reader math output or the same Speech Rule Engine
           (<abbr>SRE</abbr>) used in MathJax, both of which are customizable.</p>
-        <h1>MathQuill</h1>
+        <h2>MathQuill</h2>
         <p><a href="http://mathquill.com/" target="_blank">MathQuill</a> offers an interactive web formula editor where
           users can enter text or LaTeX-style math markup and see it rendered into MathML in real-time. Users can also
           render static formulas in a web page through its coding interface. MathQuill does not appear to offer
           support for screen readers nor other assistive technology at this time.</p>
-        <h1>LaTeX.css</h1>
+        <h2>LaTeX.css</h2>
         <p><a href="https://latex.vercel.app/" target="_blank">LaTeX.css</a> is a very cleverly constructed
           <abbr>CSS</abbr> library that faithfully reproduces LaTeX-style formatting for numerous LaTeX environments,
           providing a more seamless transition for those coming from a LaTeX background. LaTeX.css is not its own
@@ -339,7 +339,7 @@
       </article>
     </section>
     <section class="main-section" id="conversion_tools">
-      <header>Conversion Tools</header>
+      <h1>Conversion Tools</h1>
       <article>
         <p>Web display engines only read and render mathematics markup already contained in an <abbr>HTML</abbr>
           document.
@@ -382,7 +382,7 @@
           <li>LaTeX2HTML</li>
           <li>sTeX</li>
         </ol>
-        <h1>Markdown</h1>
+        <h2>Markdown</h2>
         <p><a href="https://www.markdownguide.org/getting-started/" target="_blank">Markdown</a> is not so much a
           conversion <em>tool</em> as it is a markup language itself that is meant to <em>be converted</em> into
           <abbr>HTML</abbr>. Markdown is a bridge between plain text and <abbr>HTML</abbr>, designed for fast authoring
@@ -400,7 +400,7 @@
           <abbr>HTML</abbr> by a popular tool called Pandoc. This process is described below.  Sample code is provided in the <a href="#code_examples">Code Examples</a> section.
         </p>
 
-        <h1>Pandoc</h1>
+        <h2>Pandoc</h2>
         <p><a href="https://pandoc.org/index.html" target="_blank">Pandoc</a> is an extremely powerful "universal
           document converter" capable of parsing and converting between hundreds of file formats. It is run from a
           command line interface (<abbr>CLI</abbr>) by specifying the to- and from- formats along with any special
@@ -416,13 +416,13 @@
           with its own syntax for this extra structure.</p>
         <p>We encourage you to read about the many capabilities of Pandoc at the <a href="https://pandoc.org/index.html" target="_blank">Pandoc home page</a>.</p>
 
-        <h1 id="tex4ht">TeX4ht</h1>
+        <h2 id="tex4ht">TeX4ht</h2>
         <p><a href="https://tug.org/tex4ht/" target="_blank">TeX4ht</a> was developed in 2004 to convert directly from
           TeX source files to <abbr>HTML</abbr> and several other formats. It is now included as part of the TeXLive and
           MikTeX distributions. It incorporates MathJax (and other methods) for mathematics output, includes the ability
           to add some custom <abbr>CSS</abbr> to the final <abbr>HTML</abbr> output, can convert documents written with
           <a href="#r_markdown">R Markdown</a> and <a href="https://www.overleaf.com/" target="_blank">Overleaf</a>, and has other unique features.</p>
-        <h1>LaTeXML</h1>
+        <h2>LaTeXML</h2>
         <p>
           <a href="https://math.nist.gov/~BMiller/LaTeXML/">LaTeXML</a> was developed to convert LaTeX markup to an
           internal <abbr>XML</abbr> format specifically for the <a href="https://dlmf.nist.gov/" target="_blank">Digital Library of Mathematical Functions</a> (<abbr>DLMF</abbr>) project at the <a href="https://www.nist.gov/" target="_blank">National Institute of Standards and Technology</a> (<abbr>NIST</abbr>). In turn, the
@@ -432,7 +432,7 @@
         <p>
           LaTeXML was recently used to convert the  <a href="https://ar5iv.labs.arxiv.org" target="_blank">arXiv research library to HTML</a>.  This is an exciting development that could boost accessibility adoption for mathematics and science research everywhere.
         </p>
-        <h1>LaTeX.js</h1>
+        <h2>LaTeX.js</h2>
         <p><a href="https://latex.js.org/" target="_blank">LaTeX.js</a> is an interesting engine that ports full LaTeX
           documents into <abbr>HTML</abbr> while also reproducing their original LaTeX style formatting, similar to
           LaTeX.css. The web site showcases a side by side comparison of a sample LaTeX document to the rendered
@@ -440,14 +440,14 @@
           environments. LaTeX.js uses the KaTeX engine to render mathematical formulas, and thus does not have
           accessibility support at this time.
         </p>
-        <h1>LaTeX2HTML</h1>
+        <h2>LaTeX2HTML</h2>
         <p><a href="https://www.latex2html.org/" target="_blank">LaTeX2HTML</a> was way ahead of the curve, dating back
           to 1999. It is a command line tool that converts a LaTeX document into several <abbr>HTML</abbr> files to
           provide
           a paginated navigation similar to the original LaTeX PDF output. It automatically generates necessary
           hyperlinks, recreates lists, and converts mathematics, tables, and figures as into images. While the process
           does not provide alt-text, an author can insert alt-text for all necessary components.</p>
-        <h1>sTeX</h1>
+        <h2>sTeX</h2>
         <p>
           <a href="https://kwarc.info/systems/sTeX/" target="_blank">sTeX</a> is a set of LaTeX packages designed to embed semantic information in LaTeX generated output. sTeX can generate a PDF with some annotations and a (much richer) annotated HTML document using MathML with the <a href="#openmath">OpenMath</a> (or other user chosen) reference library. sTeX also offers a plug-in for LaTeXML.
         </p>
@@ -457,7 +457,7 @@
       </article>
     </section>
     <section class="main-section" id="screen_readers">
-      <header>Screen Readers</header>
+      <h1>Screen Readers</h1>
       <article>
         <p>A screen reader is a software program that translates text from a computer screen into speech audio or
           braille. They are a cornerstone of how users with impaired vision interact with computers. When documents are
@@ -499,7 +499,7 @@
         </article>
       </section>
       <section class="main-section" id="alt_text_for_math">
-        <header>Alt-Text for Math</header>
+        <h1>Alt-Text for Math</h1>
         <article>
         <p>
           Screen readers convey mathematics through alt-text descriptions of mathematical expressions.
@@ -593,7 +593,7 @@
       </article>
     </section>
     <section class="main-section" id="math_speech_engines">
-      <header>Math Speech Engines</header>
+      <h1>Math Speech Engines</h1>
       <article>
         <p>
           There are specialized speech engines for math that provide a more natural, context-based translation of math
@@ -608,21 +608,21 @@
         alternative speech and Braille output than the default output of a general screen reader. They can also be
         customized around different spoken word conventions for math.
         </p>
-        <h1>Speech Rule Engine</h1>
+        <h2>Speech Rule Engine</h2>
         <p>
           <a href="https://speechruleengine.org/" target="_blank">Speech Rule Engine</a> (SRE) is a JavaScript based engine, originally part of the ChromeVox Screen Reader extension for the Chrome browser.  It has its own internal default semantic definitions for mathematical expressions, can generate speech translations from LaTeX or AsciiMath markup, has multiple modes of math speech output, and can translate into several languages and Nemeth Braille.  
           The SRE <a href="https://speech-rule-engine.github.io/semantic-tree-visualiser/visualise.html" target="_blank">semantic tree visualizer</a> demonstrates how it parses mathematical markup, with speech customization options.  SRE comes bundled with MathJax, can run as a standalone application, and is configurable with several browsers.
         </p>
-        <h1>MathSpeak</h1>
+        <h2>MathSpeak</h2>
         <p>
           <a href="https://www.seewritehear.com/learn/mathspeak-and-mathspeak-rules/" target="_blank">MathSpeak</a>
           was developed by Abraham Nemeth, based on <a href="https://accessinghigherground.org/handouts2013/HTCTU%20Alt%20Format%20Manuals/Math%20Accommodations/07%20MATHSPEAK.pdf" target="_blank">Nemeth Braille translation rules</a>.  It is maintained and available commercially through <a href="https://www.seewritehear.com/learn/mathspeak-and-mathspeak-rules/" target="_blank">SeeWriteHear</a>, an accessibility services provider.
         </p>
-        <h1>MathCAT</h1>
+        <h2>MathCAT</h2>
         <p>
           <a href="https://nsoiffer.github.io/MathCAT/" target="_blank">MathCAT</a> (Math Capable Assitive Technology) grew out of <a href="https://docs.wiris.com/en/mathplayer/start#using_mathplayer" target="_blank">MathPlayer</a>, both developed to translate MathML into speech and Nemeth Braille.  (MathPlayer is no longer maintained, but its documentation is still available for legacy users).  MathCAT improves upon MathPlayer's output capabilities, and will make use of MathML's upcoming <span class="inline-code">intent</span> attribute to allow authors to better control speech output of MathML expressions.
         </p>
-        <h1>Ongoing Research</h1>
+        <h2>Ongoing Research</h2>
         <p>
           There is a large volume of research on speech generation from mathematics available at <a href="https://www.semanticscholar.org/" target="_blank">Semantic Scholar</a>.  Two suggested articles are:
           <ul>
@@ -637,7 +637,7 @@
       </article>
     </section>
     <section class="main-section" id="braille">
-      <header>Math in Braille</header>
+      <h1>Math in Braille</h1>
       <article>
         <p>There are four standards for authoring and reading mathematics in Braille:</p>
         <ol>
@@ -647,7 +647,7 @@
           <li>DotsPlus</li>
         </ol>
         <p>Hardware and software for reading and authoring Braille are briefly discussed at the end of this section.</p>
-        <h1>Nemeth Braille</h1>
+        <h2>Nemeth Braille</h2>
         <p>
           The <a href="http://www.brailleauthority.org/mathscience/nemeth1972.pdf" target="_blank">Nemeth Braille Code</a>
           was created in 1946 by Dr. Abraham Nemeth to represent mathematical expressions and scientific content that was not possible with the English Braille American Edition (<abbr>EBAE</abbr>) literary Braille system alone. Nemeth Braille uses a 6-dot Braille cell, the same as literary Braille, with a mix of its own unique symbols and standard EBAE. Nemeth expressions are embedded in literary Braille between special opening and closing symbols (called <em>Nemeth Indicators</em>) that inform the reader when a mathematical or scientific expression begins and ends.
@@ -658,7 +658,7 @@
         <p>
           More recently, <a href="http://www.dotlessbraille.org/nubs.htm" target="_blank">the Nemeth Uniform Braille System</a> (<abbr>NUBS</abbr>) was proposed to better unify Nemeth Braille with literary Braille.
         </p>
-        <h1><abbr>UEB</abbr></h1>
+        <h2><abbr>UEB</abbr></h2>
         <p>
           <a href="http://www.brailleauthority.org/ueb.html" target="_blank">Unified English Braille</a>
           (<abbr>UEB</abbr>)
@@ -673,7 +673,7 @@
           <a href="https://www.aph.org" target="_blank">American Printing House</a> offers tutorials on <a href="https://nemeth.aphtech.org" target="_blank">Nemeth</a> and <a href="https://uebmath.aphtech.org" target="_blank">UEB Math</a>.
         </p>
         
-        <h1>GS8</h1>
+        <h2>GS8</h2>
         <p>
           <a href="https://web.archive.org/web/20120219024932/http://dots.physics.orst.edu/gs.html"
             target="_blank">GS8</a> Braille is named after its two creators, physicist
@@ -684,13 +684,13 @@
           GS8 is not in wide use, but may be preferable to those authoring in LaTeX.
           dCode offers an online <a href="https://www.dcode.fr/gs8-braille-code" target="_blank">GS8 encoder/decoder</a>.
         </p>
-        <h1>DotsPlus</h1>
+        <h2>DotsPlus</h2>
         <p>
           <a href="https://www.washington.edu/doit/what-dotsplus-braille" target="_blank">DotsPlus</a> is a
           two-dimensional Braille system designed to be a tactile font that mimics a written symbol.  It was
           developed by John Gardner as a means for educators to present mathematics or other scientific content to blind users without having to learn Braille.
         </p>
-        <h1>Tactile Graphs in Braille</h1>
+        <h2>Tactile Graphs in Braille</h2>
         <p>
           Dr. Gardner also pioneered a method to <a href="https://www.sciencenewsforstudents.org/article/printer-makes-visual-aids-for-people-sight-problems" target="_blank">display data and graphs with Braille</a>, and began a company, <a href="https://viewplus.com/about/" target="_blank">ViewPlus Technologies</a>, to provide the technology and services.  Please see:
           <ul>
@@ -698,7 +698,7 @@
             <li><a href="https://www.youtube.com/watch?v=XWHtAbaP63g" target="_blank">Creating tactile graphics using VP embossers and Tiger Designer</a></li>
           </ul>
         </p>
-        <h1>Reading, Writing, and Translating Braille on a Computer</h1>
+        <h2>Reading, Writing, and Translating Braille on a Computer</h2>
         <p>
           The following suggestions were taken from the article <a href="https://www.washington.edu/doit/what-are-some-techniques-creating-braille-math-materials" target="_blank">What are some techniques for creating Braille math materials?</a>, and other online resources.  This section is not comprehensive and not meant to be a definitive source.  Please be sure to consult a Braille expert at your teaching institution or a <a href="https://www.google.com/search?q=local+organizations+for+the+blind" target="_blank">local organization</a> to proofread any translations to Braille generated from software.  The Library of Congress provides a <a href="https://www.loc.gov/nls/resources/blindness-and-vision-impairment/information-advocacy-organizations/" target="_blank">list of organizations</a>. You can also contact the <a href="https://nfb.org/about-us/contact-us" target="_blank">National Federation for the Blind</a> or its <a href="https://nfb.org/about-us/state-affiliates" target="_blank">State Affiliates</a>.
         </p>
@@ -774,7 +774,7 @@
       </article>
     </section>
     <section class="main-section" id="math_in_e-books">
-      <header>Math in E-books</header>
+      <h1>Math in E-books</h1>
       <article>
         <p>
           This section discusses e-book production software geared towards creating accessible-friendly
@@ -787,7 +787,7 @@
         </ol>
           There may be a bit more of a learning curve to these programs than those mentioned in the <a href="#typesetting_software">Typesetting Software</a> section, but these programs significantly ease the entire e-book production process.
         </p>
-        <h1>PreTeXt</h1>
+        <h2>PreTeXt</h2>
         <p>
           <a href="https://pretextbook.org" target="_blank">PreTeXt</a>, originally known as MathBook XML,
           is an outgrowth of the <a href="https://utmost.aimath.org" target="_blank">Undergraduate Teaching
@@ -800,7 +800,7 @@
           can be exported to HTML, PDF, Jupyter Notebooks, Nemeth Braille (using MathJax), and other formats. For mathematics,
           PreTeXt uses a hybrid of MathML to indicate math mode, LaTeX syntax for mathematics markup, and MathJax for rendering. It can be written in any editor, and it is compiled from a command line interface. An authoring guide, sample files, and several free textbooks written with PreTeXt are all available on the <a href="https://pretextbook.org" target="_blank">PreTeXt website</a>.
         </p>
-        <h1 id="r_markdown">R Markdown</h1>
+        <h2 id="r_markdown">R Markdown</h2>
         <p>
           <a href="https://rmarkdown.rstudio.com/" target="_blank">R Markdown</a> is an extended version of Markdown that works with in tandem with the <a href="https://www.r-project.org/about.html" target="_blank">R language</a> for 
           statistical computing.  R Markdown allows users to include and execute code from R and several other languages, and export to HTML, PDF, presentation slides, and (many) other formats from the same source. R Markdown can also be used to author articles and shorter documents.
@@ -813,7 +813,7 @@
           Not only can R Markdown produce a high quality accessible document, it is also a versatile
           <a href="https://r-resources.massey.ac.nz/rmarkdown/" target="_blank"> accessible friendly authoring tool</a>. The <a href="https://CRAN.R-project.org/package=BrailleR" target="_blank">BrailleR package</a> lets users code in R directly with Braille.
         </p>
-        <h1>Calibre</h1>
+        <h2>Calibre</h2>
         <p><a href="https://calibre-ebook.com/" target="_blank">Calibre</a> is a popular open source,
           cross-platform e-book reader, management tool, and e-book authoring software. It uses
           MathJax to read LaTeX input and renders mathematics as SVG images. The online user manual
@@ -822,7 +822,7 @@
           file of the same content. It may be an easier entry point for LaTeX authors who are already
           familiar with HTML to get an ebook up and running without too much extra work.
         </p>
-        <h1>DAISY</h1>
+        <h2>DAISY</h2>
         <p><a href="" target="_blank">DAISY</a> (Digital Audiobased Information SYstem) is an international consortium
           that develops
           tools to create and publish accessible reading materials. DAISY helped create
@@ -837,7 +837,7 @@
           description to meet readers' needs. Authoring information is available
           at <a href="https://daisy.org/activities/standards/daisy/mathml/mathml-in-daisy-specification/">DAISY MathML Specifications</a>.
         </p>
-        <h1>E-Readers for Math</h1>
+        <h2>E-Readers for Math</h2>
         <p>
           The EPUB e-book standard is based on HTML, and e-book readers are based on the same core engines as web browsers. The EPUB 3 standard supports MathML, but MathML does not have universal browser support. Therefore, the same concerns apply to rendering mathematics in e-books: MathML code may be used directly, but some publishers opt for SVG images with alt-text.  Readers must check with their specific software & device to determine what level of support they have for mathematics.
         </p>
@@ -847,7 +847,7 @@
       </article>
     </section>
     <section class="main-section" id="tagged_pdf">
-      <header>Tagged PDF</header>
+      <h1>Tagged PDF</h1>
       <article>
         <p>
           <a href="" target="_blank">Tagged PDF</a> is a semantically enriched PDF that provides meta document
@@ -894,7 +894,7 @@
           structure for mathematics with LaTeX, MathML, and AsciiMath markup.
         </p>
 
-        <h1>LaTeX</h1>
+        <h2>LaTeX</h2>
         <p>
           The <a href="https://www.tug.org" target="_blank">TeX Users Group</a> (<abbr>TUG</abbr>) has been working to incorporate Tagged PDF functionality into LaTeX:
           <ul>
@@ -924,7 +924,7 @@
           Martin Ruckert's <a href="https://www.tug.org/practicaltex2018/slides/ruckert.pdf">HINT Project</a> 
           modifies TeX to have the ability to reflow text like HTML.
         </p>
-        <h1>MathML</h1>
+        <h2>MathML</h2>
         <p><a href="https://movemen.com/index.html" target="_blank">MathTools for InDesign</a> by MoveMen (not to be
           confused with the <a href="https://ctan.org/pkg/mathtools?lang=en" target="_blank">mathtools package</a> for
           LaTeX) is a commercial plugin for Adobe InDesign that allows embedding of MathML into
@@ -948,7 +948,7 @@
         </ul>
         This document suggests some support for MathML. Prince XML's official documentation does not yet mention it.
         </p>
-        <h1>AsciiMath</h1>
+        <h2>AsciiMath</h2>
         <p><a href="https://www.metanorma.org/author/approach/" target="_blank">Metanorma</a> is an open-source XML
           authoring system based on the <a href="https://docs.asciidoctor.org/">Asciidoc</a> markup language. Similar to
           the Pandoc + Markdown workflow mentioned earlier, Asciidoc + Metanorma's internal XML can output a source file
@@ -958,7 +958,7 @@
       </article>
     </section>
     <section class="main-section" id="code_examples">
-      <header>Code Examples</header>
+      <h1>Code Examples</h1>
       <article>
         <p>
           Test LaTeX code in a browser at:
@@ -974,7 +974,7 @@
           </ul>
           Note that the MathML will not display in all browsers.  Check <a href="https://caniuse.com/mathml" target="_blank">Can I Use ?</a> for your browser.
         </p>
-        <h1>Fraction</h1>
+        <h2>Fraction</h2>
         <p>$$\frac{a}{b}$$</p>
         <p>LaTeX:
         <code>\frac{a}{b}</code>
@@ -988,7 +988,7 @@
             &lt;/math&gt;
           </code> 
         </p>
-        <h1>Geometric Series</h1>
+        <h2>Geometric Series</h2>
         <p>$$S_n = \sum_{i=1}^{n} a r^{i-1} = \frac{a (1-r^n)}{1-r}$$</p>
         <p>LaTeX:
           <code>S_n = \sum_{i=1}^{n} a r^{i-1} = \frac{a(1-r^n)}{1-r}</code>
@@ -1047,7 +1047,7 @@
           &lt;/math&gt;
         </code>
         </p>
-        <h1>Markdown</h1>
+        <h2>Markdown</h2>
         <p>A Markdown file containing the LaTeX geometric series formula above:
           <code style="white-space: pre-line";> # Geometric Series
             
@@ -1055,7 +1055,7 @@
           </code>
           Note the double <span class="inline-code">$$</span> delimiters around the math expression.  This will render the equation in display format.  For inline format, use a single <span class="inline-code">$</span> delimiter.  These delimiters are not used by default in MathJax.  Please see the sample <a href="#mathjax_configuration">MathJax Configuration</a> below.
         </p>
-        <h1 id="pandoc_example">Pandoc</h1>
+        <h2 id="pandoc_example">Pandoc</h2>
         <p>A Pandoc conversion of the preceding Markdown file into HTML:
           <code>
             pandoc --mathjax -f markdown -t html -s source_filename.md -o output_filename.html
@@ -1086,7 +1086,7 @@
             &lt;/html&gt;
           </code>
         </p>
-        <h1 id="mathjax_configuration">MathJax</h1>
+        <h2 id="mathjax_configuration">MathJax</h2>
         <p>MathJax can be configured to use familiar LaTeX delimiters, such as:
           <code style="white-space: pre-line";> &lt;script&gt;
               &nbsp; MathJax = {
@@ -1105,7 +1105,7 @@
           </code>
           Many more customization options are explained in <a href="https://docs.mathjax.org/en/latest/web/configuration.html" target="_blank">MathJax Documentation</a>.
         </p>
-        <h1>LaTeXML</h1>
+        <h2>LaTeXML</h2>
         <p>
           LaTeXML works in two stages.  The first command:
           <code style="white-space: pre-line" ;> latexml source_filename.tex --dest=filename.xml</code>
@@ -1122,7 +1122,7 @@
       </article>
     </section>
     <section class="main-section" id="additional_links">
-      <header>Additional Links</header>
+      <h1>Additional Links</h1>
       <article>
         <ol>
           <li>
@@ -1181,12 +1181,12 @@
         </ol>
       </article>
     </section>
-    <footer style="margin-bottom: 5%;">
-      
-        <span style="float:left;">Copyright &copy; 2022 <a href="mailto:abbas.jaffary2@gmail.com?subject=Accessible Mathematics Page">Abbas Jaffary</a></span>
-        <span style="float:right;"><a href="#top">Back to top of page</a></span>
-      
-    </footer>
   </main>
+  <footer style="margin-bottom: 5%;">
+      
+    <span style="float:left;">Copyright &copy; 2022 <a href="mailto:abbas.jaffary2@gmail.com?subject=Accessible Mathematics Page">Abbas Jaffary</a></span>
+    <span style="float:right;"><a href="#top">Back to top of page</a></span>
+      
+  </footer>
 </body>
 </html>


### PR DESCRIPTION
Hi! Thanks for your excellent job, it's a great article about accessibility of math content!

This PR improves accessibility of this document for screen-reader users. This includes correct heading structure and fixed section structure of the page: `header` should never be nested in `nav`, and `footer` should never be nested in `main`.

There might be problems with styles after these changes, so please check the visuality. :)